### PR TITLE
Refactor command registration in CommandManager

### DIFF
--- a/bukkit/src/main/java/org/akazukin/library/command/LibraryBukkitCommandManager.java
+++ b/bukkit/src/main/java/org/akazukin/library/command/LibraryBukkitCommandManager.java
@@ -10,7 +10,7 @@ public class LibraryBukkitCommandManager extends BukkitCommandManager {
 
     public void registerCommands() {
         this.registerCommands(
-                AkazukinCommand.class
+                new AkazukinCommand()
         );
     }
 }

--- a/core/src/main/java/org/akazukin/library/command/CommandManager.java
+++ b/core/src/main/java/org/akazukin/library/command/CommandManager.java
@@ -1,27 +1,17 @@
 package org.akazukin.library.command;
 
 import lombok.Getter;
-import org.akazukin.library.LibraryPluginProvider;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
 
 @Getter
 public abstract class CommandManager<T extends ICmdSender> {
     private final List<Command<T>> commands = new ArrayList<>();
 
-    public void registerCommands(final Class<? extends Command<T>>... commands) {
+    public void registerCommands(final Command<T>... commands) {
         Arrays.stream(commands).forEach(this::registerCommand);
-    }
-
-    public void registerCommand(final Class<? extends Command<T>> command) {
-        try {
-            this.registerCommand(command.newInstance());
-        } catch (final InstantiationException | IllegalAccessException e) {
-            LibraryPluginProvider.getApi().getLogManager().log(Level.SEVERE, e.getMessage(), e);
-        }
     }
 
     public void registerCommand(final Command<T> command) {


### PR DESCRIPTION
Replaced dynamic class instantiation with direct object passing for command registration. Removed unnecessary exception handling and logging in the CommandManager. Simplified LibraryBukkitCommandManager by directly creating command instances.